### PR TITLE
ISSUE-51: Create release-drafter.yml GitHub Action

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,56 @@
+name: Release Drafter
+
+#on:
+#  push:
+#    # branches to consider in the event; optional, defaults to all
+#    branches:
+#      - master
+
+on: push
+
+jobs:
+  release-drafter:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache maven dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build
+        run: mvn -B package --file pom.xml
+
+        # Drafts your next Release notes as Pull Requests are merged into "master"
+      - name: Create draft release
+        id: create_draft_release
+        uses: release-drafter/release-drafter@v5
+        # with:
+          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+          # config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload draft release asset
+        id: upload_draft_release_asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`.
+          # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          upload_url: ${{ steps.create_draft_release.outputs.upload_url }}
+          asset_path: ./target/coffee_pot.jar
+          asset_name: coffee_pot.jar
+          asset_content_type: application/jar

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,13 +1,11 @@
 # Drafts your next Release notes as Pull Requests are merged into "master"
 name: Release Drafter
 
-#on:
-#  push:
-#    # branches to consider in the event; optional, defaults to all
-#    branches:
-#      - master
-
-on: push
+on:
+ push:
+   # branches to consider in the event; optional, defaults to all
+   branches:
+     - master
 
 jobs:
   release-drafter:
@@ -48,7 +46,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`.
+          # This pulls from the CREATE DRAFT RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`.
           # See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           upload_url: ${{ steps.create_draft_release.outputs.upload_url }}
           asset_path: ./target/coffee_pot.jar

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,3 +1,4 @@
+# Drafts your next Release notes as Pull Requests are merged into "master"
 name: Release Drafter
 
 #on:
@@ -32,7 +33,6 @@ jobs:
       - name: Build
         run: mvn -B package --file pom.xml
 
-        # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Create draft release
         id: create_draft_release
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: coffee_pot
-        path: target/coffee_pot.jar
+        path: ./target/coffee_pot.jar
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Add upload-artifact GitHub action
 - ISSUE-51 ([#55](https://github.com/odessajavaclub/coffee-pot/pull/55))
     - Create config for release-drafter GitHub Action
+- ISSUE-51 ([#54](https://github.com/odessajavaclub/coffee-pot/pull/54))
+    - Create release-drafter.yml GitHub Action
 
 ### Changed
 - ISSUE-24 ([#24](https://github.com/odessajavaclub/coffee-pot/pull/24))


### PR DESCRIPTION
## Resolves partially #51 

## Description

Create release-drafter.yml GitHub Action
This gh action requires a config (i.e. `./github/release-drafter.yml`) to be present in `master` first, see https://github.com/release-drafter/release-drafter/issues/398

Also, this config **must** be submitted first in order to verify that it works.
ProBot works only for master branch:
`17:40:39.602Z  INFO probot: odessajavaclub/coffee-pot: Ignoring push. ms-51-release-asset-gh-action is not one of: master`
See #51 for drawbacks

**Depends on** #55 

## Testing Details

- [ ] Verified basic functionality of change (Can be verified only when merged to master)
- [ ] Added tests
- [x] I have updated the change log
