### PR TITLE
ISSUE-51: Create config for release-drafter GitHub Action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,16 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+template: |
+  # What's Changed
+  $CHANGES
+categories:
+  - title: 'Enhancement'
+    label: 'type: enhancement'
+  - title: 'Bug Fixes'
+    label: 'type: bug'
+  - title: 'GitHub Actions'
+    label: 'type: github actions'
+  - title: 'Documentation'
+    label: 'type: documentation'
+  - title: 'Dependency Updates'
+    label: 'type: dependencies'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,13 +4,13 @@ template: |
   # What's Changed
   $CHANGES
 categories:
-  - title: 'Enhancement'
-    label: 'type: enhancement'
+  - title: 'Enhancements'
+    label: 'enhancement'
   - title: 'Bug Fixes'
-    label: 'type: bug'
+    label: 'bug'
   - title: 'GitHub Actions'
-    label: 'type: github actions'
+    label: 'github actions'
   - title: 'Documentation'
-    label: 'type: documentation'
+    label: 'documentation'
   - title: 'Dependency Updates'
-    label: 'type: dependencies'
+    label: 'dependencies'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     - Add maven checkstyle plugin
 - ISSUE-49 ([#50](https://github.com/odessajavaclub/coffee-pot/pull/50))
     - Add upload-artifact GitHub action
+- ISSUE-51 ([#55](https://github.com/odessajavaclub/coffee-pot/pull/55))
+    - Create config for release-drafter GitHub Action
 
 ### Changed
 - ISSUE-24 ([#24](https://github.com/odessajavaclub/coffee-pot/pull/24))


### PR DESCRIPTION
## Resolves partially #51

## Description

Create config for release-drafter gh action
It should be committed first to `master` before release-drafter gh action is added. See https://github.com/release-drafter/release-drafter/issues/398

## Testing Details

- [x] Verified basic functionality of change
- [ ] Added tests
- [x] I have updated the change log
